### PR TITLE
Experimental support for BCP payload

### DIFF
--- a/examples/bcp_nft_child.js
+++ b/examples/bcp_nft_child.js
@@ -1,0 +1,49 @@
+const {
+  BCP_TYPE_AUDIO,
+  // BCP_TYPE_VIDEO,
+  BCP_SRC_URL
+} = require('bcp-js')
+
+const childConfig = {
+  receiver: 'simpleledger:--some-receiver-address-here--',
+  group: '--TXID-FROM-CREATE-NFT-GROUP-SCRIPT--',
+  name: 'NFT BCP Tests Child',
+  ticker: 'BCPHLD'
+  payload: {
+    // type: BCP_TYPE_VIDEO,
+    type: BCP_TYPE_AUDIO,
+    source: BCP_SRC_URL,
+    // data: 'ipfs://QmTYqoPYf7DiVebTnvwwFdTgsYXg2RnuPrt8uddjfW2kHS' // monkey video
+    data: 'ipfs://QmZmqLskJmghru919cvU4qSy3L5vc1S2JdzsUXrM17ZqT9' // rain drop audio
+  }
+}
+
+const BCHJS = require('@psf/bch-js')
+const bchjs = new BCHJS()
+// const bchjs = new BCHJS({ apiToken: process.env.BCHJSTOKEN })
+
+const BCHJSNFT = require('../src/bch-js-nft')
+const nftjs = new BCHJSNFT({ bchjs })
+const path = require('path')
+
+let walletInfo
+try {
+  const loadPath = path.join(__dirname, 'wallet.json')
+  walletInfo = require(loadPath)
+} catch (err) {
+  console.log(
+    "Could not open wallet.json: { address: '...', wif: '...'}"
+  )
+  process.exit(0)
+}
+
+async function createNFTChild (walletInfo, config) {
+  try {
+    const childTxId = await nftjs.NFT.createNftChild(walletInfo, config)
+    console.log(`https://explorer.bitcoin.com/bch/tx/${childTxId}`)
+  } catch (error) {
+    console.error('error in createNFTGroup: ', error)
+  }
+}
+
+createNFTChild(walletInfo, childConfig)

--- a/examples/remove_nft_child.js
+++ b/examples/remove_nft_child.js
@@ -1,0 +1,31 @@
+const removeId = '--tokenId-to-remove--'
+
+const BCHJS = require('@psf/bch-js')
+const bchjs = new BCHJS()
+// const bchjs = new BCHJS({ apiToken: process.env.BCHJSTOKEN })
+
+const BCHJSNFT = require('../src/bch-js-nft')
+const nftjs = new BCHJSNFT({ bchjs })
+const path = require('path')
+
+let walletInfo
+try {
+  const loadPath = path.join(__dirname, 'wallet.json')
+  walletInfo = require(loadPath)
+} catch (err) {
+  console.log(
+    "Could not open wallet.json: { address: '...', wif: '...'}"
+  )
+  process.exit(0)
+}
+
+async function removeNFTChild (walletInfo, tokenId) {
+  try {
+    const burnTxId = await nftjs.NFT.removeNftChild(walletInfo, tokenId)
+    console.log(`https://explorer.bitcoin.com/bch/tx/${burnTxId}`)
+  } catch (error) {
+    console.error('error in removeNFTChild: ', error)
+  }
+}
+
+removeNFTChild(walletInfo, removeId)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "bch-js-nft",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.2",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@psf/bch-js": "^4.18.4",
-        "axios": "^0.21.1"
+        "axios": "^0.21.1",
+        "bcp-js": "^2.0.1"
       },
       "devDependencies": {
         "mocha": "^9.0.0"
@@ -705,6 +706,14 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/bcp-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bcp-js/-/bcp-js-2.0.1.tgz",
+      "integrity": "sha512-TtrE6XgY7VomAqW5clfpfh7hqtx8gOd8a7QCmYrVZ29jhNoiRySh0cIuCa/xE+qm2Rs9YnIjuy5z7VHfZQwf8A==",
+      "dependencies": {
+        "bignumber.js": "^9.0.1"
       }
     },
     "node_modules/bech32": {
@@ -6139,6 +6148,14 @@
       "requires": {
         "bs58check": "^2.1.2",
         "cashaddrjs-slp": "^0.2.12"
+      }
+    },
+    "bcp-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bcp-js/-/bcp-js-2.0.1.tgz",
+      "integrity": "sha512-TtrE6XgY7VomAqW5clfpfh7hqtx8gOd8a7QCmYrVZ29jhNoiRySh0cIuCa/xE+qm2Rs9YnIjuy5z7VHfZQwf8A==",
+      "requires": {
+        "bignumber.js": "^9.0.1"
       }
     },
     "bech32": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bch-js-nft",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "NFT extensions to @psf/bch-js library",
   "main": "src/bch-js-nft.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "homepage": "https://github.com/zh/bch-js-nft#readme",
   "dependencies": {
     "@psf/bch-js": "^4.18.4",
-    "axios": "^0.21.1"
+    "axios": "^0.21.1",
+    "bcp-js": "^2.0.1"
   },
   "devDependencies": {
     "mocha": "^9.0.0"

--- a/src/bch-js-nft.js
+++ b/src/bch-js-nft.js
@@ -4,7 +4,6 @@
 
 const DEFAULT_SLPDB_URL = 'https://slpdb.fountainhead.cash/'
 
-const BCHJS = require('@psf/bch-js')
 const NFT = require('./nft')
 
 class BCHJSNFT {
@@ -19,6 +18,7 @@ class BCHJSNFT {
     const tmp = {}
     if (!config || !config.slpdbURL) tmp.slpdbURL = DEFAULT_SLPDB_URL
     else tmp.slpdbURL = config.slpdbURL
+
     const thisConfig = {
       slpdbURL: tmp.slpdbURL,
       bchjs: this.BCH


### PR DESCRIPTION
- Trying to add BCP payload as a second OP_RETURN.
- Added also sending NFT child token via GENERIC transaction to the external receiver.
- Allow burning single NFT child tokens